### PR TITLE
docs(readme): fix typo in Notes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ MIT
 
 ## Notes
 
-### How to configure GCP Project and get create `CLIENT_ID` and `CLEINT_SECRET` values
+### How to configure GCP Project and get create `CLIENT_ID` and `CLIENT_SECRET` values
 
 You need [Google Cloud Platform](https://console.cloud.google.com/) Project to
 develop this app.


### PR DESCRIPTION
This PR fixes a small typo in the Notes section of the `README`, namely: `CLIENT_SECRET` was `CLEINT_SECRET`, I fixed this to be correct.