### PR TITLE
Fix `Uncaught RangeError: Invalid array length` on daylight saving time months

### DIFF
--- a/utils/datetime.ts
+++ b/utils/datetime.ts
@@ -210,11 +210,11 @@ export function startOfMonth(d: Date, n = 0) {
 }
 
 export function endOfMonth(d: Date, n = 0) {
-  return new Date(+new Date(d.getFullYear(), d.getMonth() + 1 + n) - DAY);
+  return new Date(d.getFullYear(), d.getMonth() + 1 + n, 0);
 }
 
 export function daysOfMonth(d: Date) {
-  return (+endOfMonth(d) - +startOfMonth(d)) / DAY + 1;
+  return endOfMonth(d).getDate();
 }
 
 export function getAvailableRangesBetween(

--- a/utils/datetime_test.ts
+++ b/utils/datetime_test.ts
@@ -2,6 +2,7 @@
 
 import {
   createRangesInRange,
+  daysOfMonth,
   getAvailableRangesBetween,
   HOUR,
   hourMinuteToSec,
@@ -496,3 +497,19 @@ Deno.test("createRangesInRange", () => {
     ],
   );
 });
+
+Deno.test("daysOfMonth", () => {
+  assertEquals(31, daysOfMonth(new Date("2022-01-05T00:00Z")));
+  assertEquals(28, daysOfMonth(new Date("2022-02-05T00:00Z")));
+  assertEquals(31, daysOfMonth(new Date("2022-03-05T00:00Z")));
+  assertEquals(30, daysOfMonth(new Date("2022-04-05T00:00Z")));
+  assertEquals(31, daysOfMonth(new Date("2022-05-05T00:00Z")));
+  assertEquals(30, daysOfMonth(new Date("2022-06-05T00:00Z")));
+  assertEquals(31, daysOfMonth(new Date("2022-07-05T00:00Z")));
+  assertEquals(31, daysOfMonth(new Date("2022-08-05T00:00Z")));
+  assertEquals(30, daysOfMonth(new Date("2022-09-05T00:00Z")));
+  assertEquals(31, daysOfMonth(new Date("2022-10-05T00:00Z")));
+  assertEquals(30, daysOfMonth(new Date("2022-11-05T00:00Z")));
+  assertEquals(31, daysOfMonth(new Date("2022-12-05T00:00Z")));
+})
+

--- a/utils/datetime_test.ts
+++ b/utils/datetime_test.ts
@@ -511,5 +511,4 @@ Deno.test("daysOfMonth", () => {
   assertEquals(31, daysOfMonth(new Date("2022-10-05T00:00Z")));
   assertEquals(30, daysOfMonth(new Date("2022-11-05T00:00Z")));
   assertEquals(31, daysOfMonth(new Date("2022-12-05T00:00Z")));
-})
-
+});


### PR DESCRIPTION
Fix `daysOfMonth` on those months when timezones apply the daylight saving time change.

On these months, the `(month_end - month_start) / DAY` division is off by 1 hour, returning
a floating point not suitable for the subsequent `Array` constructor,
failing with `Uncaught RangeError: Invalid array length`.