### PR TITLE
chore(ci): Use start-server-and-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
         run: npx firebase-tools@10.9.2 -V
 
       - name: Test
-        run: deno task firestore-emulator & sleep 30 && deno task test && kill %1
+        run: npx start-server-and-test 'deno task firestore-emulator' 4000 'deno task test'


### PR DESCRIPTION
Consider using the excellent [bahmutov/start-server-and-test](https://github.com/bahmutov/start-server-and-test) for starting a server, waiting for it to start at a port, running tests and tearing down server.