### PR TITLE
chore(deps): Check for updates weekly using udd

### DIFF
--- a/.github/workflows/udd.yml
+++ b/.github/workflows/udd.yml
@@ -1,0 +1,22 @@
+name: Update Deno Dependencies
+
+on:
+  schedule:
+    - cron: "0 18 * * 0" # Every Sunday 18:00 UTC
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: denoland/setup-deno@v1
+      - name: Update Dependencies
+        run: |
+          deno run -A https://deno.land/x/udd/main.ts ./import_map.json
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: "chore(deps): Update dependencies"
+          commit-message: "chore(deps): Update dependencies"
+          delete-branch: true

--- a/.github/workflows/udd.yml
+++ b/.github/workflows/udd.yml
@@ -1,10 +1,8 @@
-name: Update Deno Dependencies
-
+name: udd
 on:
   schedule:
-    - cron: "0 18 * * 0" # Every Sunday 18:00 UTC
+    - cron: "0 0 1 * *" # Monthly
   workflow_dispatch:
-
 jobs:
   update:
     runs-on: ubuntu-latest
@@ -13,7 +11,7 @@ jobs:
       - uses: denoland/setup-deno@v1
       - name: Update Dependencies
         run: |
-          deno run -A https://deno.land/x/udd/main.ts ./import_map.json
+          deno run -A https://deno.land/x/udd@0.8.1/main.ts ./import_map.json
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:


### PR DESCRIPTION
Consider using [hayd/deno-udd](https://github.com/hayd/deno-udd) to automatically update dependencies and send out a PR to this repo weekly (or on demand).

Just a suggestion, feel free to tweak or reject.